### PR TITLE
Add development note on home page

### DIFF
--- a/rndmforesteu/content/index.md
+++ b/rndmforesteu/content/index.md
@@ -6,7 +6,11 @@ description: ''
 ::mainheader
 Random Forest
 #subtitle
-This is a collection of projects I'm interested in. The site was created to document the proggress, share learnings and facilitate collaboration. I believe that by working together with other motivated people, you can achieve better results than anyone could alone. If you are interested in any of the initiatives and you are willing to collaborate - even if you have only a few hours per month - feel free to contact me.
+This is a collection of projects I'm interested in. The site was created to document the progress, share learnings and facilitate collaboration. I believe that by working together with other motivated people, you can achieve better results than anyone could alone. If you are interested in any of the initiatives and you are willing to collaborate - even if you have only a few hours per month - feel free to contact me.
+::
+
+::paragraph
+This website is under continuous development. New content will be added soon, so check back often for updates.
 ::
 
 ::cards

--- a/rndmforesteu/nuxt.config.ts
+++ b/rndmforesteu/nuxt.config.ts
@@ -14,6 +14,9 @@ export default defineNuxtConfig({
     nitro: {
         preset: 'service-worker'
     },
+    app: {
+        baseURL: '/rndmforest/'
+    },
     googleFonts: {
         families: {
             // https://themeisle.com/blog/best-google-fonts/#gref


### PR DESCRIPTION
## Summary
- add paragraph about ongoing development on the main page
- fix home page typo
- set base path for nuxt project

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ca09145288325899af36ea7a58255