### PR TITLE
Fix content routing with baseURL

### DIFF
--- a/rndmforesteu/pages/[...slug].vue
+++ b/rndmforesteu/pages/[...slug].vue
@@ -1,11 +1,14 @@
-<script setup>
+<script setup lang="ts">
+const route = useRoute()
+const config = useRuntimeConfig()
+const path = route.path.replace(new RegExp(`^${config.app.baseURL}`), '') || '/index'
 
-  const { data: navigation } = await useAsyncData('navigation', () => {
-    return fetchContentNavigation()
-  })
+const { data: navigation } = await useAsyncData('navigation', () => {
+  return fetchContentNavigation()
+})
 
-  // TODO: Design example
- 
+// TODO: Design example
+
 </script>
 
 <template>
@@ -22,7 +25,7 @@
       </nav>
       REST
       -->
-      <ContentDoc />
+      <ContentDoc :path="path" />
     </main>
 </template>
 

--- a/rndmforesteu/pages/pub/[...slug].vue
+++ b/rndmforesteu/pages/pub/[...slug].vue
@@ -1,6 +1,12 @@
+<script setup lang="ts">
+const route = useRoute()
+const config = useRuntimeConfig()
+const path = route.path.replace(new RegExp(`^${config.app.baseURL}`), '') || '/index'
+</script>
+
 <template>
     <main>
-      <ContentDoc>
+      <ContentDoc :path="path">
         <template #not-found> <h1 class="red">Document not found</h1> </template>
       </ContentDoc>
     </main>


### PR DESCRIPTION
## Summary
- ensure Document-Driven pages strip app.baseURL so content files resolve correctly

## Testing
- `npm run dev` *(fails: fetch to fonts.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688caba4131c8325b783dbd9978ad3a5