### PR TITLE
Add console logs for content path

### DIFF
--- a/rndmforesteu/pages/[...slug].vue
+++ b/rndmforesteu/pages/[...slug].vue
@@ -5,6 +5,7 @@ const config = useRuntimeConfig()
 const base = config.app.baseURL.replace(/\/$/, '')
 const cleanedPath = route.path.replace(new RegExp(`^${base}\/`), '')
 const path = (!cleanedPath || cleanedPath === '/') ? '/index' : cleanedPath
+console.log('Looking for content at', path)
 
 const { data: navigation } = await useAsyncData('navigation', () => {
   return fetchContentNavigation()

--- a/rndmforesteu/pages/pub/[...slug].vue
+++ b/rndmforesteu/pages/pub/[...slug].vue
@@ -5,6 +5,7 @@ const config = useRuntimeConfig()
 const base = config.app.baseURL.replace(/\/$/, '')
 const cleanedPath = route.path.replace(new RegExp(`^${base}\/`), '')
 const path = (!cleanedPath || cleanedPath === '/') ? '/index' : cleanedPath
+console.log('Looking for content at', path)
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- log out the markdown path when rendering slug pages

## Testing
- `grep -n "Looking for content" -n rndmforesteu/pages/[...slug].vue`
- `grep -n "Looking for content" -n rndmforesteu/pages/pub/[...slug].vue`


------
https://chatgpt.com/codex/tasks/task_e_688cb5b8dfd083258f2cbcca9e9896fc